### PR TITLE
fix: bugfix build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,12 +5,11 @@ buildscript {
 
     repositories {
         mavenLocal()
-        mavenCentral()
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.mparticle:android-kit-plugin:+'
+        classpath 'com.mparticle:android-kit-plugin:' + project.version
     }
 }
 


### PR DESCRIPTION
## Summary
- Fix `build.gradle` syntax blocking lint in AGP 7.X upgrade

## Testing Plan
1. Run `./gradlew publishReleaseLocal` then `./gradlew publishReleaseLocal -c settings-kits.gradle lint` locally
2. Things should compile fine