### PR TITLE
fix: disable lint check failing when kit is added as submodule

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,9 @@ android {
     defaultConfig {
         minSdkVersion 15
     }
+    lintOptions {
+        disable 'SdkMethodCalledInClassDetector'
+    }
 }
 
 subprojects {


### PR DESCRIPTION
When we run lint checks from the core project with Kits as submodules we are seeing an error:

```
com.foursquare.pilgrim.lint.checks.detectors.SdkMethodCalledInClassDetector
called context.getMainProject() during module analysis.
```

Some research indicated that we won't see any runtime problems from this so I've chalked it up to something we can safely ignore.