### PR TITLE
fix: disable lintError check when kit is added as submodule

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ android {
         minSdkVersion 15
     }
     lintOptions {
-        disable 'SdkMethodCalledInClassDetector'
+        disable 'LintError'
     }
 }
 


### PR DESCRIPTION
## Summary
- Disable lint check failing when kit is added as submodule

## Testing Plan
- This is an auto-merge from pair programming



