### PR TITLE
fix: Upgrade ktlint Gradle plugin from 11 to 13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
 
 plugins {
     id "org.sonarqube" version "3.5.0.2730"
-    id "org.jlleitschuh.gradle.ktlint" version "11.2.0"
+    id "org.jlleitschuh.gradle.ktlint" version "13.0.0"
 }
 
 sonarqube {
@@ -34,6 +34,10 @@ apply plugin: 'com.mparticle.kit'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.mparticle.kits.pilgrim'
+    buildFeatures {
+        buildConfig = true
+    }
     defaultConfig {
         minSdkVersion 16
     }


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Updated ktlint Gradle plugin from version 11 to 13 to align with latest standards.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
